### PR TITLE
updated documentation to change placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,6 @@ export default {
 - Default: `true`
 This option hides the input and displays divs that act as dummy input fields. This allows us have an "active" state in the input that changes the placeholder text colour indicating which date is being selected.
 
-### placeholder
-- Type: `String`
-- Default: `Check-in ► Check-out`
-The input placeholder text
-
 ### value
 - Type: `String`
 - Default: `' '`
@@ -193,6 +188,8 @@ i18n: {
     night: 'Night',
     nights: 'Nights',
     button: 'Close',
+    'check-in': 'Check-In',
+    'check-out': 'Check-Out',
     'day-names': ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'],
     'month-names': ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
     'error-more': 'Date range should not be more than 1 night',

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ export default {
 - Default: `true`
 This option hides the input and displays divs that act as dummy input fields. This allows us have an "active" state in the input that changes the placeholder text colour indicating which date is being selected.
 
+### placeholder
+- Type: `String`
+- Default: `Check-in ► Check-out`
+The input placeholder text (only used if dummy inputs are turned off)
+
 ### value
 - Type: `String`
 - Default: `' '`

--- a/src/components/HotelDatePicker.vue
+++ b/src/components/HotelDatePicker.vue
@@ -4,7 +4,6 @@
       class="datepicker__input"
       :value="value"
       :id="DatePickerID"
-      :placeholder="placeholder"
       type="text"
       v-on:change="updateValues"
       readonly/>
@@ -44,10 +43,6 @@ export default {
         useDummyInputs: {
           default: true,
           type: Boolean
-        },
-        placeholder: {
-          default: 'Check-in ► Check-out',
-          type: String
         },
         DatePickerID: {
           default: '1',

--- a/src/components/HotelDatePicker.vue
+++ b/src/components/HotelDatePicker.vue
@@ -4,6 +4,7 @@
       class="datepicker__input"
       :value="value"
       :id="DatePickerID"
+      :placeholder="placeholder"
       type="text"
       v-on:change="updateValues"
       readonly/>
@@ -43,6 +44,10 @@ export default {
         useDummyInputs: {
           default: true,
           type: Boolean
+        },
+        placeholder: {
+          default: 'Check-in ► Check-out',
+          type: String
         },
         DatePickerID: {
           default: '1',


### PR DESCRIPTION
In your documentation, the placeholder change was a bit wrong. I corrected it by looking at your change vendor code. This was added to i18n and not as a placeholder prop. This is update now and everyone can change the placeholder text to their needs.

Thanks for developing this port. I think in future I will add some stuff to it as well as I'm actively using it now in a project.