### PR TITLE
make preselected date range visible in dummy inputs as well

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,8 +74,7 @@
         <h3>Allow setting a default date range ( can be used to set a range from a url param )</h3>
         <DatePicker
           DatePickerID="DatePickerID6"
-          :endDate="new Date(new Date().getFullYear(), 8, 15)"
-          :value="'2017-07-14 ► 2017-07-20'"
+          :value="'2020-07-14 ► 2020-07-20'"
         />
       </div>
 

--- a/src/vendor/hotel-datepicker.js
+++ b/src/vendor/hotel-datepicker.js
@@ -284,8 +284,11 @@ export default class HotelDatepicker {
         if(this.useDummyInputs && this.input.value) {
             let preselectDates = this.input.value.split(this.separator);
 
-            startDummyText = preselectDates[0];
-            endDummyText = preselectDates[1];
+            // check if the input value can be splitted, has two parts and set it to the text output
+            if(preselectDates.isArray() && preselectDates.length === 2) {
+                startDummyText = preselectDates[0];
+                endDummyText = preselectDates[1];
+            }
         }
 
         // Generate our datepicker

--- a/src/vendor/hotel-datepicker.js
+++ b/src/vendor/hotel-datepicker.js
@@ -284,8 +284,8 @@ export default class HotelDatepicker {
         if(this.useDummyInputs && this.input.value) {
             let preselectDates = this.input.value.split(this.separator);
 
-            startDummyText = this.getDateString(new Date(preselectDates[0]));
-            endDummyText = this.getDateString(new Date(preselectDates[1]));
+            startDummyText = preselectDates[0];
+            endDummyText = preselectDates[1];
         }
 
         // Generate our datepicker

--- a/src/vendor/hotel-datepicker.js
+++ b/src/vendor/hotel-datepicker.js
@@ -277,6 +277,17 @@ export default class HotelDatepicker {
     }
 
     createDatepickerDomString() {
+        let startDummyText = this.lang('check-in'),
+            endDummyText = this.lang('check-out');
+
+        // check if a date is preselected and overwrite the dummy input field texts on init
+        if(this.useDummyInputs && this.input.value) {
+            let preselectDates = this.input.value.split(this.separator);
+
+            startDummyText = this.getDateString(new Date(preselectDates[0]));
+            endDummyText = this.getDateString(new Date(preselectDates[1]));
+        }
+
         // Generate our datepicker
         let html =
         '<button type="button" id="' + this.getClearButtonId() + '" class="datepicker__clear-button">＋</button>' +
@@ -308,8 +319,8 @@ export default class HotelDatepicker {
 
         html +=
         '<div id="dummyWrapper' + this.getDatepickerId() + '" class="datepicker__dummy-wrapper '  + (this.useDummyInputs == true ? ' ' : ' -is-hidden') +  '">' +
-            '<div id="' + this.getDatepickerId() + '_date1" class="datepicker__dummy-input">' + this.lang('check-in') + '</div> ' +
-            '<div id="' + this.getDatepickerId() + '_date2" class="datepicker__dummy-input">' + this.lang('check-out') + '</div>' +
+            '<div id="' + this.getDatepickerId() + '_date1" class="datepicker__dummy-input">' + startDummyText + '</div> ' +
+            '<div id="' + this.getDatepickerId() + '_date2" class="datepicker__dummy-input">' + endDummyText + '</div>' +
         '</div>';
 
         return html;

--- a/src/vendor/hotel-datepicker.js
+++ b/src/vendor/hotel-datepicker.js
@@ -285,7 +285,7 @@ export default class HotelDatepicker {
             let preselectDates = this.input.value.split(this.separator);
 
             // check if the input value can be splitted, has two parts and set it to the text output
-            if(preselectDates.isArray() && preselectDates.length === 2) {
+            if(preselectDates instanceof Array && preselectDates.length === 2) {
                 startDummyText = preselectDates[0];
                 endDummyText = preselectDates[1];
             }


### PR DESCRIPTION
If you want to use a preselected date range you were not able to see this preselection in the dummy inputs so far. I fixed this issue by checking on initialize the input field for a value and in case there is one set this value to the dummy field instead of the "check-in"/"check-out" strings.