### PR TITLE
Feature: check-in/check-our in the same day 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,9 +2,7 @@
   #app
     div
       DatePicker(
-        :enableCheckout='true'
-        endDate="02-02-2018"
-        :disabledDates="['2018-01-02','2018-01-05','2018-01-15','2018-01-22','2018-01-06']"
+        :minNights='0'
       )
 </template>
 

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -133,7 +133,7 @@ export default {
       type: [ Date, String, Number ]
     },
     minNights: {
-      default: 0,
+      default: 1,
       type: Number
     },
     maxNights: {


### PR DESCRIPTION
Set default min nights to 1, allow check-in check-out in the same day by setting it to 0

Relates to: https://github.com/krystalcampioni/vue-hotel-datepicker/issues/8