### PR TITLE
Add multi-changeover restraints for flexible setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ i18n: {
 }
 ```
 
+
+### changeover
+
+- Type: `String`
+- Default: `null`
+
+Flexible checkin and checkout setting, commonly used by cottage rental and hotel websites.
+Different from disabled day, it's the rule property owner can specify if that day can checkin or checkout, rather than saying it's unavailable or not.
+In this case, although one day may not allow checkin and checkout, it's not like disalbed day to block the following days.
+
+Example: if startDate is `2017-11-01`, and changeover is `CXIOC`, you will see these days not selectable for checkin `2017-11-02, 2017-11-04`.
+After select `2017-11-01` as checkin, these days will become not selectable for checkout `2017-11-02, 2017-11-03`, but it won't prevent you select any days after `2017-11-04`.
+```
+'C': allow checkin or checkout
+'I': allow checkin only
+'O': allow checkout only
+'X': no checkin or checkout
+```
+
 ## API
 
 ### hideDatepicker()

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,6 @@
           />
       </div>
 
-
       <div class="box">
         <h3>Certain dates blocked</h3>
         <DatePicker
@@ -94,6 +93,21 @@
           />
       </div>
 
+      <div class="box">
+        <h3>Changeover dates restraints</h3>
+        <p>
+          'C' checkin and checkout.
+          'I' checkin allowed only.
+          'O' checkout allowed only.
+          'X' no checkin and checkout.
+        </p>
+        <DatePicker
+          :changeover="'CCXICIOXCC'"
+          :disabledDates="[
+              '2017-12-04',
+          ]"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -58,6 +58,8 @@
                 @dayClicked='handleDayClick($event)'
                 :date='day.date'
                 :sortedDisabledDates='sortedDisabledDates'
+                :sortedChangeoverDisabledCheckinDates = 'sortedChangeoverDisabledCheckinDates'
+                :sortedChangeoverDisabledCheckoutDates = 'sortedChangeoverDisabledCheckoutDates'
                 :nextDisabledDate='nextDisabledDate'
                 :activeMonthIndex='activeMonthIndex'
                 :hoveringDate='hoveringDate'
@@ -84,6 +86,8 @@
                   @dayClicked='handleDayClick($event)'
                   :date='day.date'
                   :sortedDisabledDates='sortedDisabledDates'
+                  :sortedChangeoverDisabledCheckinDates = 'sortedChangeoverDisabledCheckinDates'
+                  :sortedChangeoverDisabledCheckoutDates = 'sortedChangeoverDisabledCheckoutDates'
                   :nextDisabledDate='nextDisabledDate'
                   :activeMonthIndex='activeMonthIndex'
                   :hoveringDate='hoveringDate'
@@ -175,6 +179,10 @@ export default {
     enableCheckout: {
       default: false,
       type: Boolean
+    },
+    changeover: {
+      default: null,
+      type: String
     }
   },
 
@@ -194,6 +202,8 @@ export default {
       xUp: null,
       yUp: null,
       sortedDisabledDates: null,
+      sortedChangeoverDisabledCheckinDates: null,
+      sortedChangeoverDisabledCheckoutDates: null,
       screenSize: this.handleWindowResize(),
     };
   },
@@ -212,6 +222,8 @@ export default {
       }
     },
     checkIn(newDate) {
+      this.parseChangeoverDisabledCheckinDates()
+      this.parseChangeoverDisabledCheckoutDates()
       this.$emit("checkInChanged", newDate )
     },
     checkOut(newDate) {
@@ -220,6 +232,8 @@ export default {
         this.nextDisabledDate = null;
         this.show = true;
         this.parseDisabledDates();
+        this.parseChangeoverDisabledCheckinDates()
+        this.parseChangeoverDisabledCheckoutDates()
         this.reRender()
         this.isOpen = false;
       }
@@ -384,6 +398,39 @@ export default {
       sortedDates.sort((a, b) =>  a - b );
 
       this.sortedDisabledDates = sortedDates;
+    },
+
+    parseChangeoverDisabledCheckinDates() {
+      const sortedDates = [];
+
+      if (this.checkIn === null || (this.checkIn !== null && this.checkOut !== null)) {
+        _.forEach(this.changeover, (c, i) => {
+          if (c !== 'C' && c !== 'I') {
+            sortedDates.push(this.addDays(this.startDate, i))
+          }
+        })
+      }
+
+      sortedDates.sort((a, b) =>  a - b );
+
+      this.sortedChangeoverDisabledCheckinDates = sortedDates
+    },
+
+    parseChangeoverDisabledCheckoutDates() {
+      const sortedDates = [];
+
+      if (this.checkIn !== null && this.checkOut === null) {
+
+        _.forEach(this.changeover, (c, i) => {
+          if (c !== 'C' && c !== 'O') {
+            sortedDates.push(this.addDays(this.startDate, i))
+          }
+        })
+      }
+
+      sortedDates.sort((a, b) =>  a - b );
+
+      this.sortedChangeoverDisabledCheckoutDates = sortedDates
     }
   },
 
@@ -391,6 +438,7 @@ export default {
     this.createMonth(new Date(this.startDate));
     this.createMonth(this.getNextMonth(new Date(this.startDate)));
     this.parseDisabledDates();
+    this.parseChangeoverDisabledCheckinDates();
   },
 
   mounted() {

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -21,6 +21,12 @@ export default {
     sortedDisabledDates: {
       type: Array
     },
+    sortedChangeoverDisabledCheckinDates: {
+      type: Array
+    },
+    sortedChangeoverDisabledCheckoutDates: {
+      type: Array
+    },
     options: {
       type: Object
     },
@@ -120,6 +126,16 @@ export default {
             }
           }
         }
+
+        // If disabled changeover checkin
+        if ( _.some(this.sortedChangeoverDisabledCheckinDates, (i) => this.compareDay(i, this.date) == 0) ) {
+          return 'datepicker__month-day datepicker__month-day--out-of-range'
+        }
+        // If disabled changeover checkout
+        if ( _.some(this.sortedChangeoverDisabledCheckoutDates, (i) => this.compareDay(i, this.date) == 0) ) {
+          return 'datepicker__month-day datepicker__month-day--out-of-range'
+        }
+
         // Highlight the selected dates and prevent the user from selecting
         // the same date for checkout and checkin
         if ( this.checkIn !== null &&


### PR DESCRIPTION
Flexible checkin and checkout setting, commonly used by cottage rental and hotel websites.

Different from disabled day, it's the rule property owner can specify if one day can checkin or checkout, rather than saying it's unavailable or not.
In this case, although one day may not allow checkin and checkout, it won't block the following days like disabled day.
```
'C': allow checkin or checkout
'I': allow checkin only
'O': allow checkout only
'X': no checkin or checkout
```

Example: if startDate is `2017-11-01`, and changeover is `CXIOC`, you cannot select these days for checkin `2017-11-02, 2017-11-04`.
After select `2017-11-01` as checkin, you cannot select `2017-11-02, 2017-11-03` for checkout, but it won't prevent you select any days like `2017-11-04` or after.

The following image is before and after select checkin with this (startDate is the day I test 2017-11-01):
`<DatePicker :changeover="'CCXICIOXCC'" :disabledDates="['2017-12-04']"/>`

![checkin](https://user-images.githubusercontent.com/7259194/32292816-a408b362-bf17-11e7-8a6b-da612026d246.png)

![checkout](https://user-images.githubusercontent.com/7259194/32292827-a99b4038-bf17-11e7-8c6f-952299f590d2.png)