### PR TITLE
Added initial date property

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,7 +73,8 @@
       <div class="box">
         <h3>Allow setting a default date range ( can be used to set a range from a url param )</h3>
         <DatePicker
-          :value="'2020-07-14 ► 2020-07-20'"
+          :startingDateValue="new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate())"
+          :endingDateValue="new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 5)"
         />
       </div>
 

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -126,6 +126,14 @@ export default {
     value: {
       type: String
     },
+    startingDateValue: {
+      default: null,
+      type: Date
+    },
+    endingDateValue: {
+      default: null,
+      type: Date 
+    },
     format: {
       default: 'YYYY-MM-DD',
       type: String
@@ -181,8 +189,8 @@ export default {
   data() {
     return {
       hoveringDate: null,
-      checkIn: null,
-      checkOut: null,
+      checkIn: this.startingDateValue,
+      checkOut: this.endingDateValue,
       currentDate: new Date(),
       months: [],
       activeMonthIndex: 0,


### PR DESCRIPTION
Added a property where you can add initial date for starting and ending date. Props added:

### startingDateValue
- Type: `Date`
- Default: `null`

### endingDateValue
- Type: `Date`
- Default: `null`

Example code:
```
<DatePicker :startingDateValue="new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate())" :endingDateValue="new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 5)" />
```
