### PR TITLE
Add type='button' to clear button to avoid form submit

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -17,7 +17,7 @@
         type="text"
         readonly
       )
-    button.datepicker__clear-button(@click='clearSelection') ＋
+    button.datepicker__clear-button(type='button' @click='clearSelection') ＋
     .datepicker( :class='`${ !isOpen ? "datepicker--closed" : "datepicker--open" }`')
       .-hide-on-desktop
         .datepicker__dummy-wrapper.datepicker__dummy-wrapper--no-border(


### PR DESCRIPTION
Clicking a `<button>` inside a `<form>` will submit the form by default. This means when using the datepicker inside an HTML form, the clear button will also submit the form...

This PR adds `type='button'` to the clear button to override the default behaviour to submit the form (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type).