### PR TITLE
fixes horizontal scroll issue on mobile devices

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -133,7 +133,7 @@ export default {
     },
     endingDateValue: {
       default: null,
-      type: Date 
+      type: Date
     },
     format: {
       default: 'YYYY-MM-DD',
@@ -745,7 +745,7 @@ $font-small: 14px;
       }
     }
 
-    @include device($tablet-up) {
+    @include device($desktop) {
       &:last-of-type {
         padding-right: 0;
         padding-left: 10px;


### PR DESCRIPTION
there is an issue that is causing a horizontal scroll once the datepicker is open on mobile (landscape view) and tablet (portrait view).

this fixes the issue by adding the padding only on large screens