### PR TITLE
Bug Fixed - Duplicate month

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -357,6 +357,11 @@
       },
 
       renderNextMonth() {
+        if (this.activeMonthIndex < this.months.length - 2) {
+          this.activeMonthIndex++;
+          return
+        }
+
         let firstDayOfLastMonth;
 
         if (this.screenSize !== 'desktop') {


### PR DESCRIPTION
If you go forward to next month, everything works good. But then, if you go to previous month and then to next month. It creates a duplicate month.

![captura](https://user-images.githubusercontent.com/34795714/42923187-93ebc09e-8b24-11e8-9fd9-f1b2d0bc61a3.PNG)
