### PR TITLE
Cursor:pointer for desktop+ hovering over squares

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -490,6 +490,9 @@
     .square {
         width: calc(100% / 7);
         float: left;
+        @include device($desktop) {
+          cursor: pointer;
+        }
     }
 
     *,


### PR DESCRIPTION
Uses the text cursor currently (default) implies no clickable action on desktop. Quick change to a pointer to make it look clickable, disabled dates are still the disabled cursor.