### PR TITLE
Use currentDateStyle instead of hardcoded border

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -6,7 +6,7 @@
       @keyup.enter.prevent.stop='dayClicked(date)'
       v-text='dayNumber'
       :class='dayClass'
-      :style='isToday ? "border: 1px solid #00c690" : ""'
+      :style='isToday ? currentDateStyle : ""'
       :tabindex="tabIndex"
       ref="day"
     )


### PR DESCRIPTION
The previous PR #107 didn't solve the #103 issue entirely probably because of [the merge](https://github.com/krystalcampioni/vue-hotel-datepicker/pull/107/commits/5b26407c64f68d16655b8e9f7c23e99183329c1d). This adds the missing part on the Day component.