### PR TITLE
Hotfix style in Safari. Closes #202

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -96,6 +96,7 @@
     }
 
     &__input {
+        appearance: none;
         background: transparent;
         height: 4em;
         color: $primary-text-color;
@@ -106,8 +107,6 @@
         word-spacing: 0.4166666666666666666666666666666em;
         border: 0;
         @include focusStyle();
-        appearance: none;
-        
         &::-webkit-input-placeholder,
         &::-moz-placeholder,
         &:-ms-input-placeholder,

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -106,7 +106,8 @@
         word-spacing: 0.4166666666666666666666666666666em;
         border: 0;
         @include focusStyle();
-
+        appearance: none;
+        
         &::-webkit-input-placeholder,
         &::-moz-placeholder,
         &:-ms-input-placeholder,


### PR DESCRIPTION
Add `appearance: none;` to datepicker input to work properly with safari 