### PR TITLE
Fix document querySelector null on datepicker__month element

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,7 +57,7 @@
             @keyup.enter.stop.prevent='renderNextMonth'
             :tabindex='isOpen ? 0 : -1'
           )
-        .datepicker__months(v-if='screenSize == "desktop"')
+        .datepicker__months(v-if='screenSize === "desktop"')
           div.datepicker__month(v-for='n in [0,1]'  v-bind:key='n')
             p.datepicker__month-name(v-text='getMonth(months[activeMonthIndex+n].days[15].date)')
             .datepicker__week-row.-hide-up-to-tablet
@@ -295,10 +295,13 @@ export default {
         if (value) {
           bodyClassList.add('-overflow-hidden');
           setTimeout(() => {
-            let swiperWrapper = document.getElementById('swiperWrapper');
-            let monthHeihgt = document.querySelector('.datepicker__month')
-              .offsetHeight;
-            swiperWrapper.scrollTop = this.activeMonthIndex * monthHeihgt;
+            const swiperWrapper = document.getElementById('swiperWrapper');
+            let monthEl = document.querySelector('.datepicker__month')
+            let monthHeight = 1
+
+            if (monthEl) monthHeight = monthEl.offsetHeight;
+
+            swiperWrapper.scrollTop = this.activeMonthIndex * monthHeight;
           }, 100);
         } else {
           bodyClassList.remove('-overflow-hidden');


### PR DESCRIPTION
Hey! thank you for your package 👍 

I found a bug, in mobile, you tried to use `querySelector` on an element that does not exist.

In fact, `datepicker__month` does not exist in mobile because of this line https://github.com/krystalcampioni/vue-hotel-datepicker/pull/215/files#diff-ea994a51b0d9884f4fc046eca11a5c99R60 which is a contradiction.

My PR is a dirty fix that prevents the package to raise an error. But I think we need to dig deeper to find a proper solution.

Thank in advance
 