### PR TITLE
fix: wrong path for helpers, add dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+dist/

--- a/src/components/DatePicker/index.vue
+++ b/src/components/DatePicker/index.vue
@@ -266,7 +266,7 @@ import fecha from "fecha";
 
 import Day from "../Day.vue";
 import DateInput from "../DateInput.vue";
-import Helpers from "../helpers";
+import Helpers from "../../helpers";
 
 const defaulti18n = {
   night: "Night",

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -36,7 +36,7 @@
 
 <script>
 import fecha from "fecha";
-import Helpers from "./helpers";
+import Helpers from "../helpers";
 import BookingBullet from "./BookingBullet.vue";
 
 export default {


### PR DESCRIPTION
Fix broken build caused by wrong relative import of `helpers.js` in 2 files.

Also added `dist/` directory to `.gitignore`