### PR TITLE
Add `price` argument to `periodDates` doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Key                                  | Type       | Description
   startAt                            | String     | YYYY-MM-DD
   minimumDuration                    | Number     | Minimum stay (Type: weekly => per_week | Type: nightly => per night)
   periodType                         | String     | *nightly*, *weekly_by_saturday*, *weekly_by_sunday*
+  price                              | Float      | Price displayed on each day for this period
 
 
 Example:


### PR DESCRIPTION
This PR adds the `price` argument to the documentation of `periodDates`: it was present in the description and in the examples, but not in the detailed list of arguments.