### PR TITLE
fix: remove unnecessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "files": [
     "dist/*",
-    "src/*",
-    "*.json"
+    "src/*"
   ],
   "dependencies": {
     "@vue/eslint-config-airbnb": "^5.1.0",


### PR DESCRIPTION
`vue-hotel-datepicker@4.0.0-beta.9` includes `.prettierrc.json` and `codealike.json`.
