### PR TITLE
chore: reduce dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,9 +3475,9 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-rc.2.tgz",
-          "integrity": "sha512-cz8GK4dgIf1UTC+do80pGvh8BHcCRHLIQVHV9ONVQ8wtoqS9t/+H02rKcQP+TVNg7khgLyQV2+8eHUq7/AFq3g==",
+          "version": "npm:vue-loader@16.0.0",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0.tgz",
+          "integrity": "sha512-R20f4PWe34dqhTZ9tkyFd6nfjxEbLBHbFOsN38qg0Jl8GKMfmoyc/E8vVjjRkunE6qCydpPoH7f/tW13bD6+JA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5975,7 +5975,8 @@
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -15584,7 +15585,8 @@
     "vue": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
+      "dev": true
     },
     "vue-eslint-parser": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
     "src/*",
     "*.json"
   ],
+  "peerDependencies": {
+    "vue": "2"
+  },
   "dependencies": {
-    "core-js": "^3.6.5",
     "fecha": "^4.2.0",
-    "lodash.throttle": "^4.1.1",
-    "vue": "^2.6.12"
+    "lodash.throttle": "^4.1.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.6",
@@ -58,6 +59,7 @@
     "prettier": "^1.19.1",
     "sass": "^1.26.10",
     "sass-loader": "^8.0.2",
+    "vue": "^2.6.12",
     "vue-template-compiler": "^2.6.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,6 @@
 dependencies:
-  core-js: 3.6.5
   fecha: 4.2.0
   lodash.throttle: 4.1.1
-  vue: 2.6.12
 devDependencies:
   '@vue/cli-plugin-babel': 4.5.9_8ae91920fb9b3c76895c2e8acb765728
   '@vue/cli-plugin-eslint': 4.5.9_6778c0324b153720448c6ab0d5359212
@@ -19,6 +17,7 @@ devDependencies:
   prettier: 1.19.1
   sass: 1.26.10
   sass-loader: 8.0.2_sass@1.26.10
+  vue: 2.6.12
   vue-template-compiler: 2.6.12
 lockfileVersion: 5.2
 packages:
@@ -3475,6 +3474,7 @@ packages:
     resolution:
       integrity: sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
   /core-js/3.6.5:
+    dev: true
     requiresBuild: true
     resolution:
       integrity: sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -10668,7 +10668,7 @@ packages:
     resolution:
       integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
   /vue/2.6.12:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
   /w3c-hr-time/1.0.2:
@@ -11135,7 +11135,6 @@ specifiers:
   '@vue/test-utils': ^1.1.0
   babel-eslint: ^10.1.0
   chai: ^4.2.0
-  core-js: ^3.6.5
   eslint: ^6.8.0
   eslint-plugin-prettier: ^3.1.4
   eslint-plugin-vue: ^6.2.2


### PR DESCRIPTION
`core-js` is needed when building and it's included in `@vue/cli-plugin-babel`.
(`@vue/cli-plugin-babel` -> `@vue/babel-preset-app` -> `core-js`)