### PR TITLE
feat!: change showYear to monthFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ If provided, it will override the default tooltip "X nights" with the text provi
 - Default `MMMM YYYY`
 
 The month format string.
+The default format shows a month name like `January 2020`.
+
+⚠️ The option `showYear` has been removed since v4. If you need to change the display of the month name, you can use this option.
+```html
+<!-- Old: Shows the year next to the month name like `January 2020` -->
+<HotelDatePicker showYear />
+<!-- New: Shows the year next to the month name like `January 2020` -->
+<HotelDatePicker /> or <HotelDatePicker monthFormat="MMMM YYYY" />
+
+<!-- Old: Shows the month name only like `January` -->
+<HotelDatePicker /> or <HotelDatePicker :showYear="false" />
+<!-- New: Shows the month name only like `January` -->
+<HotelDatePicker monthFormat="MMMM" />
+```
 
 ## closeDatepickerOnClickOutside
 - Type: `boolean`

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ If provided, it will override the default tooltip "X nights" with the text provi
 - Type `boolean`
 - Default `false`
 
-## showYear
+## monthFormat
 
-- Type `boolean`
-- Default `false`
+- Type `String`
+- Default `MMMM YYYY`
 
-Shows the year next to the month
+The month format string.
 
 ## closeDatepickerOnClickOutside
 - Type: `boolean`
@@ -385,7 +385,7 @@ Emitted every time a booking is clicked
 
 Params:
 name                | Type       | Description
---------------------|-------------------------
+--------------------|------------|------------
   event             | MouseEvent | Mouse javascript event
   date              | Date       | Clicked Date
   currentBooking    | Object     | Clicked Booking
@@ -404,8 +404,9 @@ Example of currentBooking:
 ### periodSelected
 Emitted every time when a checkOut is clicked
 
+Params:
 name                | Type       | Description
---------------------|-------------------------
+--------------------|------------|------------
   event             | MouseEvent | Mouse javascript event
   checkIn           | Date       | checkIn
   checkIn           | Date       | checkOut

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
                 <option value="es">Español</option>
                 <option value="pt">Português</option>
                 <option value="fr">Français</option>
+                <option value="ja">日本語</option>
             </select>
         </div>
         <div class="container">
@@ -21,7 +22,7 @@
                 <h3>
                     Calendar in full view
                 </h3>
-                <DatePicker :alwaysVisible="true" :showYear="true" :i18n="i18n" />
+                <DatePicker :alwaysVisible="true" monthFormat="MMMM YYYY" :i18n="i18n" />
             </div>
             <div class="box">
                 <h3>
@@ -59,7 +60,7 @@
                     <strong>lastDateAvailable</strong> props <br />
                     <small style="font-weight: normal">Stop pagination two years later</small>
                 </h3>
-                <DatePicker :lastDateAvailable="lastDateAvailable" :showYear="true" :i18n="i18n" />
+                <DatePicker :lastDateAvailable="lastDateAvailable" :i18n="i18n" />
             </div>
             <div class="box">
                 <h3>Show prices with <strong>periodDates</strong></h3>
@@ -176,7 +177,11 @@
             </div>
             <div class="box">
                 <h3>Hide year</h3>
-                <DatePicker :showYear="false" :i18n="i18n" />
+                <DatePicker monthFormat="MMMM" :i18n="i18n" />
+            </div>
+            <div class="box">
+                <h3>Custom month format (YYYY年M月)</h3>
+                <DatePicker monthFormat="YYYY年M月" :i18n="i18n" />
             </div>
             <div class="box">
                 <h3>Custom date format (MMMM D)</h3>
@@ -219,6 +224,7 @@ import pt from './i18n/pt'
 import fr from './i18n/fr'
 import en from './i18n/en'
 import es from './i18n/es'
+import ja from './i18n/ja'
 
 export default {
     components: {
@@ -227,7 +233,7 @@ export default {
     data() {
         return {
             language: 'en',
-            languages: { pt, fr, en, es },
+            languages: { pt, fr, en, es, ja },
             periodDates: [
                 {
                     startAt: '2021-07-01',
@@ -335,9 +341,6 @@ export default {
         }
     },
     computed: {
-        dateFormat() {
-            return 'DD/MM/YYYY'
-        },
         lastDateAvailable() {
             return this.addYears(new Date(), 2)
         },
@@ -410,7 +413,7 @@ body {
     }
 }
 .vhd__datepicker__wrapper {
-    max-width: 300px;
+    max-width: 350px;
     &.vhd__datepicker__fullview {
         max-width: 90%;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,7 @@
                 <h3>
                     Calendar in full view
                 </h3>
-                <DatePicker :alwaysVisible="true" monthFormat="MMMM YYYY" :i18n="i18n" />
+                <DatePicker :alwaysVisible="true" :i18n="i18n" />
             </div>
             <div class="box">
                 <h3>

--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -110,7 +110,7 @@
                         :key="`${datepickerMonthKey}-${month}`"
                     >
                         <p class="vhd__datepicker__month-name">
-                            {{ getMonth(months[activeMonthIndex + month].days[15].date) }}
+                            {{ getMonthName(months[activeMonthIndex + month].days[15].date) }}
                         </p>
                         <div class="vhd__datepicker__week-row vhd__hide-up-to-tablet">
                             <div
@@ -185,7 +185,7 @@
                             :key="`${datepickerMonthKey}-${n}`"
                         >
                             <p class="vhd__datepicker__month-name">
-                                {{ getMonth(months[n].days[15].date) }}
+                                {{ getMonthName(months[n].days[15].date) }}
                             </p>
                             <div class="vhd__datepicker__week-row vhd__hide-up-to-tablet">
                                 <div
@@ -242,7 +242,7 @@
 
 <script>
 import throttle from 'lodash.throttle'
-import fecha from 'fecha'
+import { format } from 'fecha'
 
 import Day from './components/Day.vue'
 import DateInput from './components/DateInput.vue'
@@ -370,9 +370,9 @@ export default {
             type: Boolean,
             default: false,
         },
-        showYear: {
-            type: Boolean,
-            default: true,
+        monthFormat: {
+            type: String,
+            default: 'MMMM YYYY',
         },
         closeDatepickerOnClickOutside: {
             type: Boolean,
@@ -560,18 +560,6 @@ export default {
         },
     },
     created() {
-        fecha.i18n = {
-            dayNames: this.i18n['day-names'],
-            dayNamesShort: this.shortenString(this.i18n['day-names'], 3),
-            monthNames: this.i18n['month-names'],
-            monthNamesShort: this.shortenString(this.i18n['month-names'], 3),
-            amPm: ['am', 'pm'],
-            // D is the day of the month, function returns something like...  3rd or 11th
-            DoFn(D) {
-                return D + ['th', 'st', 'nd', 'rd'][D % 10 > 3 ? 0 : ((D - (D % 10) !== 10) * D) % 10]
-            },
-        }
-
         if (
             this.checkIn &&
             (this.getMonthDiff(this.getNextMonth(new Date(this.startDate)), this.checkIn) > 0 ||
@@ -1148,10 +1136,7 @@ export default {
             }
 
             if (this.endDate !== Infinity) {
-                if (
-                    fecha.format(firstDayOfLastMonth[0].date, 'YYYYMM') ===
-                    fecha.format(new Date(this.endDate), 'YYYYMM')
-                ) {
+                if (format(firstDayOfLastMonth[0].date, 'YYYYMM') === format(new Date(this.endDate), 'YYYYMM')) {
                     return
                 }
             }
@@ -1165,11 +1150,14 @@ export default {
         setCheckOut(date) {
             this.checkOut = date
         },
-        getMonth(date) {
-            return (
-                this.i18n['month-names'][fecha.format(date, 'M') - 1] +
-                (this.showYear ? fecha.format(date, ' YYYY') : '')
-            )
+        getMonthName(date) {
+            const i18n = { monthNames: this.i18n['month-names'] }
+
+            if ('month-names-short' in this.i18n) {
+                i18n.monthNamesShort = this.i18n['month-names-short']
+            }
+
+            return format(date, this.monthFormat, i18n)
         },
         createMonth(date) {
             const firstDay = this.getFirstDay(date, this.firstDayOfWeek)

--- a/src/DatePicker/components/Day.vue
+++ b/src/DatePicker/components/Day.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import fecha from 'fecha'
+import { format } from 'fecha'
 import Helpers from '../../helpers'
 import BookingBullet from './BookingBullet.vue'
 
@@ -164,7 +164,7 @@ export default {
             )
         },
         dayNumber() {
-            return fecha.format(this.date, 'D')
+            return format(this.date, 'D')
         },
         dayPrice() {
             let currentDate = null
@@ -307,7 +307,7 @@ export default {
 
                 // Only highlight dates that are not disabled
                 if (this.isHighlighted && !this.isDisabled) {
-                    if (this.options.disabledDaysOfWeek.some(i => i === fecha.format(this.date, 'dddd'))) {
+                    if (this.options.disabledDaysOfWeek.some(i => i === format(this.date, 'dddd'))) {
                         return 'vhd__datepicker__month-day--selected vhd__datepicker__month-day--disabled afterMinimumDurationValidDay'
                     }
 
@@ -356,10 +356,7 @@ export default {
                 }
 
                 // Good
-                if (
-                    this.isDisabled ||
-                    this.options.disabledDaysOfWeek.some(i => i === fecha.format(this.date, 'dddd'))
-                ) {
+                if (this.isDisabled || this.options.disabledDaysOfWeek.some(i => i === format(this.date, 'dddd'))) {
                     return 'vhd__datepicker__month-day--disabled'
                 }
             } else if (!this.belongsToThisMonth) {
@@ -641,7 +638,7 @@ export default {
                 // Or is after the end date
                 this.compareEndDay() ||
                 // Or is in one of the disabled days of the week
-                this.options.disabledDaysOfWeek.some(i => i === fecha.format(this.date, 'dddd'))
+                this.options.disabledDaysOfWeek.some(i => i === format(this.date, 'dddd'))
 
             // Handle checkout enabled
             if (this.options.enableCheckout) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 /* eslint-disable vars-on-top */
-import fecha from 'fecha'
+import { format } from 'fecha'
 
 export default {
     getNextDate(datesArray, referenceDate) {
@@ -156,15 +156,6 @@ export default {
 
         return d2M + 12 * d2Y - (d1M + 12 * d1Y)
     },
-    shortenString(arr, sLen) {
-        const newArr = []
-
-        for (let i = 0, len = arr.length; i < len; i++) {
-            newArr.push(arr[i].substr(0, sLen))
-        }
-
-        return newArr
-    },
     getDaysArray(start, end) {
         for (
             // eslint-disable-next-line no-var
@@ -178,11 +169,28 @@ export default {
         // eslint-disable-next-line block-scoped-var
         return arr
     },
-    dateFormater(date, format) {
-        const f = format || 'YYYY-MM-DD'
+    dateFormater(date, dateFormat) {
+        const f = dateFormat || 'YYYY-MM-DD'
 
         if (date) {
-            return fecha.format(date, f)
+            const i18n = {
+                monthNames: this.i18n['month-names'],
+                dayNames: this.i18n['day-names'],
+            }
+
+            if ('month-names-short' in this.i18n) {
+                i18n.monthNamesShort = this.i18n['month-names-short']
+            }
+
+            if ('day-names-short' in this.i18n) {
+                i18n.dayNamesShort = this.i18n['day-names-short']
+            }
+
+            if ('do-fn' in this.i18n) {
+                i18n.DoFn = this.i18n['do-fn']
+            }
+
+            return format(date, f, i18n)
         }
 
         return ''
@@ -198,8 +206,8 @@ export default {
         return new Date(time1) < new Date(time2)
     },
     compareDay(day1, day2) {
-        const date1 = fecha.format(new Date(day1), 'YYYYMMDD')
-        const date2 = fecha.format(new Date(day2), 'YYYYMMDD')
+        const date1 = format(new Date(day1), 'YYYYMMDD')
+        const date2 = format(new Date(day2), 'YYYYMMDD')
 
         if (date1 > date2) {
             return 1

--- a/src/i18n/ja.js
+++ b/src/i18n/ja.js
@@ -1,0 +1,17 @@
+export default {
+    night: '泊',
+    nights: '泊',
+    week: '週',
+    weeks: '週',
+    'day-names': ['日', '月', '火', '水', '木', '金', '土'],
+    'check-in': 'チェックイン',
+    'check-out': 'チェックアウト',
+    'month-names': ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+    tooltip: {
+        halfDayCheckIn: 'チェックイン可',
+        halfDayCheckOut: 'チェックアウト可',
+        saturdayToSaturday: '土曜日から日曜日のみ',
+        sundayToSunday: '日曜日から日曜日のみ',
+        minimumRequiredPeriod: '%{minNightInPeriod} %{night} 以上にしてください。',
+    },
+}


### PR DESCRIPTION
Thank you for useful library.

In Japan, the month displayed as "January 2020" is displayed as "2020年1月".
So `showYear` is not suitable in some languages.

What do you think of this change?