### PR TITLE
Add new Events & Fixes Related to Single Month View

### DIFF
--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -1219,7 +1219,7 @@ export default {
       }
     },
     renderNextMonth: throttle(function throttleRenderNextMonth() {
-      if (this.activeMonthIndex < this.months.length - 2) {
+      if ((!this.showSingleMonth && this.activeMonthIndex < this.months.length - 2) || (this.showSingleMonth && this.activeMonthIndex < this.months.length - 1)) {
         this.activeMonthIndex++
 
         return
@@ -1227,7 +1227,7 @@ export default {
 
       let firstDayOfLastMonth
 
-      if (!this.isDesktop) {
+      if (!this.isDesktop || this.showSingleMonth) {
         firstDayOfLastMonth = this.months[this.months.length - 1].days.filter((day) => day.belongsToThisMonth === true)
       } else {
         firstDayOfLastMonth = this.months[this.activeMonthIndex + 1].days.filter(

--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -711,7 +711,10 @@ export default {
         this.activeMonthIndex += count
       } else {
         this.createMonth(new Date(this.startDate))
-        this.createMonth(this.getNextMonth(new Date(this.startDate)))
+
+        if (!this.showSingleMonth) {
+          this.createMonth(this.getNextMonth(new Date(this.startDate)))
+        }
       }
     },
     handleBookingClicked(event, date, currentBooking) {

--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -1222,7 +1222,15 @@ export default {
     },
     renderPreviousMonth() {
       if (this.activeMonthIndex >= 1) {
-        this.activeMonthIndex--
+
+      const firstDayOfLastMonth = this.months[this.activeMonthIndex].days.filter(
+          (day) => day.belongsToThisMonth === true,
+      )
+      const previousMonth = this.getPreviousMonth(firstDayOfLastMonth[0].date)
+
+      this.activeMonthIndex--
+
+      this.$emit('previous-month-rendered', previousMonth)
       }
     },
     renderNextMonth: throttle(function throttleRenderNextMonth() {

--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -893,12 +893,15 @@ export default {
 
       if (this.checkIn == null && !this.singleDaySelection) {
         this.checkIn = date
+        this.$emit('check-in-selected', date)
         this.setMinimumDuration(date)
       } else if (this.singleDaySelection) {
         this.checkIn = date
+        this.$emit('check-in-selected', date)
         this.checkOut = date
       } else if (this.checkIn !== null && this.checkOut == null && this.isDateLessOrEquals(date, this.checkIn)) {
         this.checkIn = date
+        this.$emit('check-in-selected', date)
       } else if (this.checkIn !== null && this.checkOut == null) {
         this.checkOut = date
         this.$emit('period-selected', event, this.checkIn, this.checkOut)
@@ -909,6 +912,7 @@ export default {
       } else {
         this.checkOut = null
         this.checkIn = date
+        this.$emit('check-in-selected', date)
         this.setMinimumDuration(date)
       }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -99,6 +99,17 @@ const helpers = {
 
     return nextMonth
   },
+  getPreviousMonth(date) {
+    let prevMonth
+
+    if (date.getMonth() === 0) {
+      prevMonth = new Date(date.getFullYear() - 1, 11, 1)
+    } else {
+      prevMonth = new Date(date.getFullYear(), date.getMonth() - 1, 1)
+    }
+
+    return prevMonth
+  },
   handleTouchStart(evt) {
     this.isTouchMove = false
 


### PR DESCRIPTION
#277 

**Issues in single month view:**
1) Let's suppose today is September 6, 2021. If we pass :singleMonth="true" and endDate="2021-11-15", it will stop paginating at October and will not allow us to go to November which is basically the month of endDate.

2) Create two months in generateInitialMonths() method even if we pass :singleMonth="true". The disadvantage of this is when we are in singleMonth view and the current month is September, the next-month-rendered with send November as its argument instead of October.

**Fixes**
1) In case of :singleMonth="true", the pagination will now stop at the month of end date rather than a month before the month of end date, while the existing behavior for double months will remain the same

2) In case of :singleMonth="true", generateInitialMonths() method will create one month, while the default behavior for double months will remain the same.

**Events Added**
1) 'previous-month-rendered' event will emit whenever user will click on previous month.
2) 'check-in-selected' event will emit whenever user will click on check in date irrespective of whether it is the consecutive click on the same checkin date or not. ('check-in-changed' event does not trigger when selects the same check in date consecutively).