### PR TITLE
Fix Generate Initial Months in case of Single Month View

### DIFF
--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -694,9 +694,10 @@ export default {
       ) {
         this.createMonth(new Date(this.startDate))
         const count = this.getMonthDiff(this.startDate, this.checkIn)
+        const monthCount = this.showSingleMonth ? count - 1 : count
         let nextMonth = new Date(this.startDate)
 
-        for (let i = 0; i <= count; i++) {
+        for (let i = 0; i <= monthCount; i++) {
           const tempNextMonth = this.getNextMonth(nextMonth)
 
           this.createMonth(tempNextMonth)


### PR DESCRIPTION
**Bug:**
Create months up to check-in month + 1 month in generateInitialMonths() method's **if condition**, even if we pass :singleMonth="true". The disadvantage of this is when we are in singleMonth view and the current month is November, the next-month-rendered event will not trigger for the very next month (December), it will work for months next to December though as they aren't created yet.

**Fix**
In case of :singleMonth="true", generateInitialMonths() method will create months up to checkin-month, while the default behavior for double months will remain the same.

P.S. I've already half fixed this issue in #277