### PR TITLE
Bump Node.js version to 24 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 


### PR DESCRIPTION
Update the Node.js version in the GitHub Actions workflow to ensure compatibility with the latest features and improvements.